### PR TITLE
[BCN-3536] Added support of new Mali prefixes

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -396,6 +396,8 @@ var (
 	FIRST_GROUP_ONLY_PREFIX_PATTERN = regexp.MustCompile("\\(?\\$1\\)?")
 
 	REGION_CODE_FOR_NON_GEO_ENTITY = "001"
+
+	MaliNationalPhoneRegExp = regexp.MustCompile("^(?:2(?:0(?:01|79)|17\\d)\\d{4}|(?:5[01]|[6789]\\d|8[2-49])\\d{6})$")
 )
 
 // INTERNATIONAL and NATIONAL formats are consistent with the definition
@@ -2159,7 +2161,19 @@ func isNumberMatchingDesc(nationalNumber string, numberDesc *PhoneNumberDesc) bo
 // just looking at a number itself.
 func IsValidNumber(number *PhoneNumber) bool {
 	var regionCode string = GetRegionCodeForNumber(number)
-	return IsValidNumberForRegion(number, regionCode)
+	isValid := IsValidNumberForRegion(number, regionCode)
+	// Mali raised new phone number prefix 85 which is still not supported by the latest version
+	// of libphonenumber. So we need to validate it manually.
+	if regionCode == "ML" {
+		return validateNewMaliPrefix(number)
+	}
+
+	return isValid
+}
+
+func validateNewMaliPrefix(number *PhoneNumber) bool {
+	var nationalSignificantNumber = GetNationalSignificantNumber(number)
+	return MaliNationalPhoneRegExp.Match([]byte(nationalSignificantNumber))
 }
 
 // Tests whether a phone number is valid for a certain region. Note this

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -197,6 +197,11 @@ func Test_IsValidNumber(t *testing.T) {
 			isValid: true,
 			region:  "US",
 		}, {
+			input:   "+22385050597",
+			err:     nil,
+			isValid: true,
+			region:  "ML",
+		}, {
 			input:   "+244972577111",
 			err:     nil,
 			isValid: true,


### PR DESCRIPTION
 - 🎫 [BCN-3536](https://retool.atlassian.net/browse/BCN-3536)
 
Mali has raised a support of new prefix **85** which unfortunately is not supported by the latest version of libphonenumber. 
<img width="683" alt="Screenshot 2024-10-24 at 16 31 01" src="https://github.com/user-attachments/assets/b41d3636-70eb-4298-b6e9-078e8fa7201c">

Added manual check into `IsValidNumber` method to handle that case

[BCN-3536]: https://retool.atlassian.net/browse/BCN-3536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ